### PR TITLE
Better debugging error

### DIFF
--- a/src/Api/GenerateImageCommand.php
+++ b/src/Api/GenerateImageCommand.php
@@ -33,7 +33,8 @@ class GenerateImageCommand implements ApiCommandInterface
         $parsedResponse = json_decode($response->getBody()->getContents(), true);
 
         if (!is_array($parsedResponse) || !isset($parsedResponse['data'])) {
-            throw new RuntimeException('Response format unsupported.');
+            $error = $parsedResponse['error']['message'] ?? 'Response format unsupported.';
+            throw new RuntimeException($error);
         }
 
         return $parsedResponse['data'];


### PR DESCRIPTION
In my case the message was confusing

 > Billing hard limit has been reached

This fixes it to be more concrete.

PS: Is the normal token not allowed to be used anymore (free mode)? Does it now need to have a paid subscription to test/demo image generation?